### PR TITLE
Show metatag if dns or url verification

### DIFF
--- a/commands/tls.js
+++ b/commands/tls.js
@@ -6,29 +6,28 @@ module.exports = {
   topic: 'fastly',
   command: 'tls',
   description: 'Add/Remove Fastly TLS to DOMAIN',
-  help: 'DOMAIN will be added to a Fastly/Heroku SAN SSL certificate. \n\n\
+  help: 'DOMAIN will be added to a Fastly Heroku SAN SSL certificate. \n\n\
 Requirements: \n\
- - The Fastly Service must have DOMAIN configured in the active version. \n\
- - Heroku pricing plan must include TLS Domain(s)\n\
+ - The Fastly Service must have DOMAIN configured in the active version \n\
+ - Heroku pricing plan must include TLS Domain(s) \n\
  - Wildcard domains are not allowed \n\n\
 You must verify ownership of DOMAIN after running this command. \n\
-Valid VERIFICATION_TYPES provided by our CA are: email, dns, url \n\
-We strongly reccomend using DNS verification. Typically it is the easiest and quickest way to verify.\n\n\
-  Email: Email approval sent to an address the CA specifies as the owner of the domain. This is usually admin, administrator, hostmaster, postmaster, or webmaster @<your_domain>\n\
-  DNS: Create a DNS TXT record with the provided metatag. \n\
-  URL: Create a HTML META-tag in the HEAD section of the root page on your domain with the provided metatag. Please note that they cannot reside on a page under the root domain.\n\n\
+Valid VERIFICATION_TYPES are: dns, email, url \n\
+  DNS (recommended): Create a DNS TXT record with the provided metatag via your DNS provider. \n\
+  Email: Verification email sent to the domain owner. This is usually admin, administrator, hostmaster, postmaster, or webmaster @<your_domain>\n\
+  URL: Create a HTML META-tag with the provided content in the HEAD section of the root page on your domain. Please note that they cannot reside on a page under the root domain.\n\n\
 Usage: \n\
    heroku fastly:tls www.example.org dns --app my-fast-app\n\
    heroku fastly:tls -d www.example.org --app my-fast-app',
   needsApp: true,
   needsAuth: true,
   args: [
-    {name: 'domain', description: 'the domain to add TLS'},
-    {name: 'verification_type', description: 'The method to use for domain verification. Must be one of: email, dns, or url', optional: true},
+    {name: 'domain', description: 'The domain for TLS configure'},
+    {name: 'verification_type', description: 'The domain verification method to use. Must be dns, email, or url', optional: true},
   ],
   flags: [
     {name: 'delete', char: 'd', description: 'Remove TLS from DOMAIN', hasValue: false},
-    {name: 'api_key', char: 'k', description: 'Override Fastly_API_KEY config var', hasValue: true},
+    {name: 'api_key', char: 'k', description: 'Override FASTLY_API_KEY config var', hasValue: true},
     {name: 'api_uri', char: 'u', description: 'Override Fastly API URI', hasValue: true}
   ],
   run: hk.command(function* (context, heroku) {

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -13,11 +13,10 @@ Requirements: \n\
  - Wildcard domains are not allowed \n\n\
 You must verify ownership of DOMAIN after running this command. \n\
 Valid VERIFICATION_TYPES provided by our CA are: email, dns, url \n\
-We reccomend using DNS verification because its usually the easiest change to make.\n\n\
+We strongly reccomend using DNS verification. Typically it is the easiest and quickest way to verify.\n\n\
   Email: Email approval sent to an address the CA specifies as the owner of the domain. This is usually admin, administrator, hostmaster, postmaster, or webmaster @<your_domain>\n\
   DNS: Create a DNS TXT record with the provided metatag. \n\
-  URL: Create a HTML META-tag in the HEAD section of the root page on your domain with the provided metatag. Please note that they cannot reside on a page under the root domain.\n\
-Some details can be found at: https://support.globalsign.com/customer/portal/articles/1345666-verify-domain-ownership---approver-url-method- \n\n\
+  URL: Create a HTML META-tag in the HEAD section of the root page on your domain with the provided metatag. Please note that they cannot reside on a page under the root domain.\n\n\
 Usage: \n\
    heroku fastly:tls www.example.org dns --app my-fast-app\n\
    heroku fastly:tls -d www.example.org --app my-fast-app',

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -61,8 +61,6 @@ Usage: \n\
       });
 
     } else { 
-      // domain addition is default command
-
       if (!context.args.verification_type) {
         hk.error('VERIFICATION_TYPE is required to provision TLS. Use: email, dns, or url');
         process.exit(1);
@@ -84,7 +82,7 @@ Usage: \n\
         } else {
           hk.styledHeader(context.args.domain + " queued for TLS addition.");
           hk.warn("Please proceed with domain verification. You chose to verify using " + context.args.verification_type);
-          var parsed = JSON.parse(body)
+          var json = JSON.parse(body)
           switch(context.args.verification_type.toLowerCase())  {
             case 'email':
               hk.warn("Email Verification: An email with a verification link will be sent to one of: admin@, administrator@, hostmaster@, postmaster@, webmaster@, or the email listed in the WHOIS record");
@@ -92,14 +90,16 @@ Usage: \n\
 
             case 'dns':
               hk.warn("DNS Verification: Create a DNS TXT record containing the following content");
-              hk.warn("globalsign-domain-verification=" + parsed.metatag);
+              hk.warn("globalsign-domain-verification=" + json.metatag);
               break;
 
             case 'url':
               hk.warn("URL Verification: Insert the following metatag into the <head> section on the root page of your site");
-              hk.warn("<meta name=\"globalsign-domain-verification\" content=\"" + parsed.metatag + "\"/>");
+              hk.warn("<meta name=\"globalsign-domain-verification\" content=\"" + json.metatag + "\"/>");
               break;
           }
+          hk.warn("Configure the following CNAME *after* domain verification:\n")
+          hk.warn("CNAME  " + json.order.domain + "  " + json.fqdn);
         }
       });
     }


### PR DESCRIPTION
This add support for outputting a copy/paste-able dns txt record or url metatag when one of those is the domain verification option. This also updates the help text output to be more clear about what each type of verification entails.