### PR TITLE
use the cert name instead of the fqdn for CNAME

### DIFF
--- a/commands/tls.js
+++ b/commands/tls.js
@@ -74,13 +74,13 @@ Usage: \n\
           service_id: config.FASTLY_SERVICE_ID
         }
       }, function(err, response, body) {
+        var json = JSON.parse(body);
         if (response.statusCode != 200) {
-          hk.error("Fastly API request Error! code: " + response.statusCode + " " + response.statusMessage + " " + JSON.parse(body).msg);
+          hk.error("Fastly API request Error! code: " + response.statusCode + " " + response.statusMessage + " " + json.msg);
           process.exit(1);
         } else {
           hk.styledHeader(context.args.domain + " queued for TLS addition.");
           hk.warn("Please proceed with domain verification. You chose to verify using " + context.args.verification_type);
-          var json = JSON.parse(body)
           switch(context.args.verification_type.toLowerCase())  {
             case 'email':
               hk.warn("Email Verification: An email with a verification link will be sent to one of: admin@, administrator@, hostmaster@, postmaster@, webmaster@, or the email listed in the WHOIS record");

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -97,7 +97,7 @@ Usage: \n\
               break;
           }
           hk.warn("Configure the following CNAME *after* domain verification:\n")
-          hk.warn("CNAME  " + json.order.domain + "  " + json.fqdn);
+          hk.warn("CNAME  " + json.order.domain + "  " + json.name);
         }
       });
     }


### PR DESCRIPTION
This changes `*.a.heroku.ssl.fastly.net` to `a.heroku.ssl.fastly.net`

- [ ] Change is live on api.fastly.com