### PR TITLE
Adds Verify Commands to Heroku-Fastly CLI Tls Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ $ heroku plugins:install heroku-fastly
 ```
 
 # Usage
-The CLI Plugin includes two commands - `purge` and `tls`.
+The CLI Plugin includes the commands - `purge`, `verify`, and `tls`.
 
 ## TLS
 To add TLS to a domain your pricing plan must include a TLS domain and the domain must be configured in the active version of your Fastly Service.
+The process involves creating the TLS Domain, verifying ownership of your domain, and checking the verification status of your domain.
 
 ```
 Usage: heroku fastly:tls DOMAIN [VERIFICATION_TYPE]
@@ -24,8 +25,21 @@ Usage: heroku fastly:tls DOMAIN [VERIFICATION_TYPE]
 To add TLS/SSL to a custom domain:
 
 ```
-heroku fastly:tls www.example.org dns --app my-fast-app
+heroku fastly:tls www.example.org --app my-fast-app
 ```
+Create a DNS TXT record with the verification string output from this command.
+
+```
+heroku fastly:verify start www.example.org --app my-fast-app
+```
+Verfies ownership of the domain via the DNS TXT record added from output of the previous command.
+
+
+```
+heroku fastly:tls status www.example.org --app my-fast-app
+```
+Checks the status of the verification process. If complete, a new CNAME will be output that you can update to after the new certificate propages to all caches.
+
 
 To remove TLS/SSL from a custom domain, include the the `-d` flag:
 

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -79,8 +79,8 @@ Usage: \n\
           hk.warn("globalsign-domain-verification=" + json.metatag);
           }
           hk.warn("Configure the following CNAME *after* domain verification:\n")
-          var cname = json.fqdn.replace("*.", "");
-          hk.warn("CNAME  " + json.order.domain + "  " + cname);
+          var fqdn = json.fqdn.replace("*.", "");
+          hk.warn("CNAME  " + json.order.domain + "  " + fqdn);
         
       });
     }

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -71,11 +71,11 @@ Usage: \n\
           process.exit(1);
         } else {
           hk.styledHeader("Domain " + context.args.domain + " has been queued for TLS certificate addition. This may take a few minutes.");
-          hk.warn("In the mean time, you can continue by starting the domain verification process. You chose to verify using " + context.args.verification_type);
+          hk.warn("In the mean time, you can continue by starting the domain verification process.");
 
           var json = JSON.parse(body)
           
-          hk.warn("DNS Verification: Create a DNS TXT record containing the following content\n");
+          hk.warn("Create a DNS TXT record containing the following content\n");
           hk.warn("globalsign-domain-verification=" + json.metatag);
           }
           hk.warn("Configure the following CNAME *after* domain verification:\n")

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -20,7 +20,6 @@ Usage: \n\
   needsAuth: true,
   args: [
     {name: 'domain', description: 'The domain for TLS configure'},
-    {name: 'verification_type', description: 'The domain verification method to use. Must be dns.', optional: true},
   ],
   flags: [
     {name: 'delete', char: 'd', description: 'Remove TLS from DOMAIN', hasValue: false},

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -71,17 +71,12 @@ Usage: \n\
           process.exit(1);
         } else {
           hk.styledHeader("Domain " + context.args.domain + " has been queued for TLS certificate addition. This may take a few minutes.");
-          hk.warn("In the mean time, you can continue by starting the domain verification process.");
+          hk.warn("In the mean time, you can continue by starting the domain verification process with `heroku fastly:verify start DOMAIN`.");
 
           var json = JSON.parse(body)
-          
           hk.warn("Create a DNS TXT record containing the following content\n");
           hk.warn("globalsign-domain-verification=" + json.metatag);
           }
-          hk.warn("Configure the following CNAME *after* domain verification:\n")
-          var fqdn = json.fqdn.replace("*.", "");
-          hk.warn("CNAME  " + json.order.domain + "  " + fqdn);
-        
       });
     }
   })

--- a/commands/verify.js
+++ b/commands/verify.js
@@ -17,11 +17,7 @@ function* app (context, heroku) {
   var url = base_uri + '/plugin/heroku/tls/status' + url_params;
   let approval = null;
 
-console.log(url);
-console.log(api_key);
-
   if  (context.args.verification_action.toLowerCase() == "start") {
-  //start
   request.get({url: url, headers: {'Fastly-Key': api_key}}, function (error, response, body) {
     if (!error && response.statusCode == 200) {
       let json = JSON.parse(body);
@@ -47,15 +43,14 @@ console.log(api_key);
         }, function(err, response, body) {
           if (!error && response.statusCode == 200) {
             cli.warn("Domain queued for verification. This takes approximately 30 minutes. To check the status, run 'heroku fastly:verify status <domain> --app <app_name>'");
-          } else { //POST req error
+          } else {
             cli.error(body);
           }
         });
 
-
       });
     }
-    else { //GET req error
+    else {
       cli.error(body);
     }
   });
@@ -76,8 +71,6 @@ if (context.args.verification_action.toLowerCase() == "status") {
     }
     });
   }
-
-
 
 }
 

--- a/commands/verify.js
+++ b/commands/verify.js
@@ -62,7 +62,7 @@ if (context.args.verification_action.toLowerCase() == "status") {
     if (!error && response.statusCode == 200) {
       let json = JSON.parse(body);
       cli.warn("State:" + json.state,  "Approvals:"  + json.approvals.toString());
-        if (json.state == "issued") {
+        if (json.state == "created") {
           cli.warn("Your cert has been issued. It can take up to an hour for it to become available. To check its availability, navigate to 'https://www.ssllabs.com/ssltest/' ")
         }
     }

--- a/commands/verify.js
+++ b/commands/verify.js
@@ -61,9 +61,15 @@ if (context.args.verification_action.toLowerCase() == "status") {
     request.get({url: url, headers: {'Fastly-Key': api_key}}, function (error, response, body) {
     if (!error && response.statusCode == 200) {
       let json = JSON.parse(body);
-      cli.warn("State:" + json.state,  "Approvals:"  + json.approvals.toString());
-        if (json.state == "created") {
-          cli.warn("Your cert has been issued. It can take up to an hour for it to become available. To check its availability, navigate to 'https://www.ssllabs.com/ssltest/' ")
+        cli.warn("Staatus: " + json.state);
+        if (json.state == "issued") {
+          cli.warn("Your cert has been issued. It can take up to an hour for it to become available. To check its availability, you can navigate to 'https://www.ssllabs.com/ssltest/' \n")
+          cli.warn("Configure the following CNAME when the cert becomes available:\n")
+          var fqdn = json.fqdn.replace("*.", "");
+          console.log(json);
+          hk.warn("CNAME  " + context.args.domain + "  " + json.fqdn);
+        } else {
+          cli.warn("Your cert has not yet been issued.")
         }
     }
     else {
@@ -84,7 +90,6 @@ module.exports = {
   args: [
     {name: 'verification_action', description: 'Start the verification process, check on its status, or confirm its completion.', optional: false},
     {name: 'domain', description: 'The domain to verify', optional: false}
-    
   ],
   flags: [
     {name: 'api_key', char: 'k', description: 'Override Fastly_API_KEY config var', hasValue: true},

--- a/commands/verify.js
+++ b/commands/verify.js
@@ -18,7 +18,8 @@ function* app (context, heroku) {
   let approval = null;
 
   if  (context.args.verification_action.toLowerCase() == "start") {
-  request.get({url: url, headers: {'Fastly-Key': api_key}}, function (error, response, body) {
+    request.get({url: url, headers: {'Fastly-Key': api_key}}, function (error, response, body) {
+
     if (!error && response.statusCode == 200) {
       let json = JSON.parse(body);
       cli.warn("Valid approval domains: " + json.approvals.toString());
@@ -42,12 +43,11 @@ function* app (context, heroku) {
           }
         }, function(err, response, body) {
           if (!error && response.statusCode == 200) {
-            cli.warn("Domain queued for verification. This takes approximately 30 minutes. To check the status, run 'heroku fastly:verify status <domain> --app <app_name>'");
+            cli.warn("Domain queued for verification. This may take up to 30 minutes. To check the status, run 'heroku fastly:verify status DOMAIN --app APP'");
           } else {
             cli.error(body);
           }
         });
-
       });
     }
     else {
@@ -59,22 +59,22 @@ function* app (context, heroku) {
 
 if (context.args.verification_action.toLowerCase() == "status") {
     request.get({url: url, headers: {'Fastly-Key': api_key}}, function (error, response, body) {
-    if (!error && response.statusCode == 200) {
-      let json = JSON.parse(body);
-        cli.warn("Staatus: " + json.state);
+
+      if (!error && response.statusCode == 200) {
+        let json = JSON.parse(body);
+        cli.warn("Status: " + json.state);
         if (json.state == "issued") {
-          cli.warn("Your cert has been issued. It can take up to an hour for it to become available. To check its availability, you can navigate to 'https://www.ssllabs.com/ssltest/' \n")
+          cli.warn("Your cert has been issued, but it may take 30 minutes or longer to become available globaly. To check availability, you can test your domain at 'https://www.ssllabs.com/ssltest/' \n")
           cli.warn("Configure the following CNAME when the cert becomes available:\n")
-          var fqdn = json.fqdn.replace("*.", "");
-          console.log(json);
-          hk.warn("CNAME  " + context.args.domain + "  " + json.fqdn);
+          var cname = json.cname.replace("*.", "");
+          cli.warn("CNAME  " + context.args.domain + "  " + cname);
         } else {
-          cli.warn("Your cert has not yet been issued.")
+          cli.warn("Your cert has not yet been issued. Please try again shortly.")
         }
-    }
-    else {
-      cli.error(body);
-    }
+      }
+      else {
+        cli.error(body);
+      }
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -7,5 +7,5 @@ exports.topic = {
 exports.commands = [
   require('./commands/purge'),
   require('./commands/tls'),
-  require('./commands/verify')
+  require('./commands/verify'),
 ];


### PR DESCRIPTION
Adds commands for domain verification to the heroku cli

To start domain verification: heroku fastly:verify <domain> start --app <app>
To check the status: heroku fastly:verify <domain> status --app <app>

Currently marked as "do not merge" until further review