### PR TITLE
⬆️ heroku-cli-util with corresponding app changes

### DIFF
--- a/commands/verify.js
+++ b/commands/verify.js
@@ -1,90 +1,7 @@
 'use strict'
 const cli = require('heroku-cli-util')
 const request = require('request')
-
-function* app(context, heroku) {
-  let baseUri = context.flags.api_uri || 'https://app.fastly.com'
-  let config = yield heroku
-    .apps(context.app)
-    .configVars()
-    .info()
-  let apiKey = context.flags.api_key || config.FASTLY_API_KEY
-
-  if (!apiKey) {
-    cli.error(
-      'config var FASTLY_API_KEY not found! The Fastly add-on is required to configure TLS. Install Fastly at https://elements.heroku.com/addons/fastly'
-    )
-    process.exit(1)
-  }
-
-  const urlParams = `?domain=${context.args.domain}&service_id=${config.FASTLY_SERVICE_ID}`
-  const url = `${baseUri}/plugin/heroku/tls/status${urlParams}`
-
-  if (context.args.verification_action.toLowerCase() == 'start') {
-    request.get({ url, headers: { 'Fastly-Key': apiKey } }, function(error, response, body) {
-      if (!error && response.statusCode == 200) {
-        let json = JSON.parse(body)
-        cli.warn(`Valid approval domains: ${json.metadata.valid_approvals.toString()}`)
-
-        cli
-          .prompt('Type the approval domain to use (or ENTER if only 1): ')
-          .then(function(approval) {
-            let valid = json.metadata.valid_approvals.indexOf(approval)
-
-            if (valid == -1) {
-              cli.error('Entered domain does not match a valid approval. Try again')
-              process.exit(1)
-            }
-
-            request(
-              {
-                method: 'POST',
-                url: `${baseUri}/plugin/heroku/tls/verify`,
-                headers: { 'Fastly-Key': apiKey },
-                form: {
-                  approval,
-                  domain: context.args.domain,
-                  service_id: config.FASTLY_SERVICE_ID, // eslint-disable-line camelcase
-                },
-              },
-              function(err, response, body) {
-                if (!error && response.statusCode == 200) {
-                  cli.warn(
-                    "Domain queued for verification. This may take up to 30 minutes. To check the status, run 'heroku fastly:verify status DOMAIN --app APP'"
-                  )
-                } else {
-                  cli.error(body)
-                }
-              }
-            )
-          })
-      } else {
-        cli.error(body)
-      }
-    })
-  }
-
-  if (context.args.verification_action.toLowerCase() == 'status') {
-    request.get({ url, headers: { 'Fastly-Key': apiKey } }, function(error, response, body) {
-      if (!error && response.statusCode == 200) {
-        let json = JSON.parse(body)
-        cli.warn(`Status: ${json.state}`)
-        if (json.state == 'issued') {
-          cli.warn(
-            'Your certificate has been issued. It could take up to an hour for the certificate to propagate globally.\n'
-          )
-          cli.warn('To use the certificate configure the following CNAME record: \n')
-          const [{ cname }] = json.dns
-          cli.warn(`CNAME  ${context.args.domain}  ${cname}`)
-        } else {
-          cli.warn('Your cert has not yet been issued. Please try again shortly.')
-        }
-      } else {
-        cli.error(body)
-      }
-    })
-  }
-}
+const co = require('co')
 
 module.exports = {
   topic: 'fastly',
@@ -113,5 +30,86 @@ module.exports = {
     },
     { name: 'api_uri', char: 'u', description: 'Override Fastly API URI', hasValue: true },
   ],
-  run: cli.command(app),
+  run: cli.command(function(context, heroku) {
+    return co(function*() {
+      let baseUri = context.flags.api_uri || 'https://app.fastly.com'
+      let config = yield heroku.get(`/apps/${context.app}/config-vars`)
+      let apiKey = context.flags.api_key || config.FASTLY_API_KEY
+
+      if (!apiKey) {
+        cli.error(
+          'config var FASTLY_API_KEY not found! The Fastly add-on is required to configure TLS. Install Fastly at https://elements.heroku.com/addons/fastly'
+        )
+        process.exit(1)
+      }
+
+      const urlParams = `?domain=${context.args.domain}&service_id=${config.FASTLY_SERVICE_ID}`
+      const url = `${baseUri}/plugin/heroku/tls/status${urlParams}`
+
+      if (context.args.verification_action.toLowerCase() == 'start') {
+        request.get({ url, headers: { 'Fastly-Key': apiKey } }, function(error, response, body) {
+          if (!error && response.statusCode == 200) {
+            let json = JSON.parse(body)
+            cli.warn(`Valid approval domains: ${json.metadata.valid_approvals.toString()}`)
+
+            cli
+              .prompt('Type the approval domain to use (or ENTER if only 1): ')
+              .then(function(approval) {
+                let valid = json.metadata.valid_approvals.indexOf(approval)
+
+                if (valid == -1) {
+                  cli.error('Entered domain does not match a valid approval. Try again')
+                  process.exit(1)
+                }
+
+                request(
+                  {
+                    method: 'POST',
+                    url: `${baseUri}/plugin/heroku/tls/verify`,
+                    headers: { 'Fastly-Key': apiKey },
+                    form: {
+                      approval,
+                      domain: context.args.domain,
+                      service_id: config.FASTLY_SERVICE_ID, // eslint-disable-line camelcase
+                    },
+                  },
+                  function(err, response, body) {
+                    if (!error && response.statusCode == 200) {
+                      cli.warn(
+                        "Domain queued for verification. This may take up to 30 minutes. To check the status, run 'heroku fastly:verify status DOMAIN --app APP'"
+                      )
+                    } else {
+                      cli.error(body)
+                    }
+                  }
+                )
+              })
+          } else {
+            cli.error(body)
+          }
+        })
+      }
+
+      if (context.args.verification_action.toLowerCase() == 'status') {
+        request.get({ url, headers: { 'Fastly-Key': apiKey } }, function(error, response, body) {
+          if (!error && response.statusCode == 200) {
+            let json = JSON.parse(body)
+            cli.warn(`Status: ${json.state}`)
+            if (json.state == 'issued') {
+              cli.warn(
+                'Your certificate has been issued. It could take up to an hour for the certificate to propagate globally.\n'
+              )
+              cli.warn('To use the certificate configure the following CNAME record: \n')
+              const [{ cname }] = json.dns
+              cli.warn(`CNAME  ${context.args.domain}  ${cname}`)
+            } else {
+              cli.warn('Your cert has not yet been issued. Please try again shortly.')
+            }
+          } else {
+            cli.error(body)
+          }
+        })
+      }
+    })
+  }),
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "heroku-fastly",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "heroku-cli-util": "^5.8.0",
-    "request": "^2.69.0",
-    "fastly": "^2.2.1"
+    "co": "^4.6.0",
+    "fastly": "^2.2.1",
+    "heroku-cli-util": "^8.0.10",
+    "request": "^2.69.0"
   },
   "devDependencies": {
     "@fastly/eslint-config": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroku-fastly",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Heroku CLI Plugin for interacting with Fastly CDN",
   "homepage": "https://www.fastly.com",
   "main": "index.js",


### PR DESCRIPTION
* `co` package was needed due to heroku-cli-util changes
* Update purge, tls and verify to be functional. Had to make changes to heroku-fastly, due to heroku-cli-util update
* ⬆️ heroku-fastly. Publish to npm after merge

Verified working:

```
alam@youthphase heroku-fastly (amy/update-deps-fix) 🌓 $ npm install
up to date in 0.865s
alam@youthphase heroku-fastly (amy/update-deps-fix) 🌓 $ heroku fastly:tls www.sparklehorse.info --app rails-esi-test
=== Domain www.sparklehorse.info has been queued for TLS certificate addition. This may take a few minutes.
 ▸    In the mean time, start the domain verification process by creating a DNS TXT record containing the following content:
 ▸
 ▸
 ▸    Once you have added this TXT record you can start the verification process by running:
 ▸
 ▸    $ heroku fastly:verify start DOMAIN —app APP
alam@youthphase heroku-fastly (amy/update-deps-fix) 🌓 $ heroku fastly:purge --all --app rails-esi-test
{ status: 'ok' }
```

Relates to: #17

Thank you @evrowe and @andriantoniades for all of the help! 💛

Change from when we paired: I was able to go up to the latest version of `heroku-cli-util`!