### PR TITLE
🔊fix error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-### 2.0.0
+### 2.0.1
+
+* 🔊 Add better error reporting
+
+## 2.0.0
 
 * Rename package from heroku-fastly to @fastly/heroku-plugin
 
@@ -29,7 +33,7 @@
 * upgrade `fastly` dependency
 * display CNAME when verification is complete
 
-### 1.0.0
+## 1.0.0
 
 * first implementation of `verify` command
 * improve messaging of `tls` command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,79 @@
-### 2.0.1
+## 2.0.1
 
-* 🔊 Add better error reporting
+### Added
+
+- 🔊 better error reporting
+
+### Changed
+
+- 📝 Changelog now in https://keepachangelog.com/en/1.0.0/ format
 
 ## 2.0.0
 
-* Rename package from heroku-fastly to @fastly/heroku-plugin
+### Changed
 
-### 1.0.7
+- Rename package from heroku-fastly to @fastly/heroku-plugin
 
-* Use api.fastly.com instead of app.fastly.com for API access
+## 1.0.7
 
-### 1.0.6
+### Changed
 
-* update dependencies
+- Use api.fastly.com instead of app.fastly.com for API access
 
-### 1.0.5
+## 1.0.6
 
-* downgrade heroku-cli-util dependency
+### Changed
 
-### 1.0.4
+- update dependencies
 
-* upgrade heroku-cli-util dependency
+## 1.0.5
 
-### 1.0.3
+### Changed
 
-* set `files` in `package.json`, as now required by ocliff
+- downgrade heroku-cli-util dependency
 
-### 1.0.2
+## 1.0.4
 
-* improve messaging of `tls` and `verify` commands
-* add soft-purge option
-* upgrade `fastly` dependency
-* display CNAME when verification is complete
+### Changed
+
+- upgrade heroku-cli-util dependency
+
+## 1.0.3
+
+### Changed
+
+- set `files` in `package.json`, as now required by ocliff
+
+## 1.0.2
+
+### Added
+
+- improve messaging of `tls` and `verify` commands
+- add soft-purge option
+- display CNAME when verification is complete
+
+### Changed
+
+- upgrade `fastly` dependency
 
 ## 1.0.0
 
-* first implementation of `verify` command
-* improve messaging of `tls` command
-* less logging
+### Added
 
-### 0.0.3
+- first implementation of `verify` command
+- improve messaging of `tls` command
 
-* output copyable metatag for `dns` and `url` verifications
-* `tls` command prints CNAME
-* improve help text
+### Changed
+
+- less logging
+
+## 0.0.3
+
+### Added
+
+- `tls` command prints CNAME
+- improve help text
+
+### Changed
+
+- output copyable metatag for `dns` and `url` verifications

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -119,7 +119,9 @@ Usage: \n\
                 )
                 hk.warn('$ heroku fastly:verify start DOMAIN —app APP')
               } else {
-                hk.warn('Unable to process this request.')
+                hk.warn(
+                  'Unable to process this request. Please wait a few minutes and try your request again. If the problem persists, please contact support@fastly.com ❤️'
+                )
               }
             }
           }

--- a/commands/tls.js
+++ b/commands/tls.js
@@ -73,16 +73,17 @@ Usage: \n\
           }
         )
       } else {
+        const form = {
+          domain: context.args.domain,
+          verification_type: 'dns', // eslint-disable-line camelcase
+          service_id: config.FASTLY_SERVICE_ID, // eslint-disable-line camelcase
+        }
         request(
           {
             method: 'POST',
             url: `${baseUri}/plugin/heroku/tls`,
             headers: { 'Fastly-Key': apiKey, 'Content-Type': 'application/json' },
-            form: {
-              domain: context.args.domain,
-              verification_type: 'dns', // eslint-disable-line camelcase
-              service_id: config.FASTLY_SERVICE_ID, // eslint-disable-line camelcase
-            },
+            form,
           },
           function(err, response, body) {
             if (response.statusCode != 200) {
@@ -93,20 +94,33 @@ Usage: \n\
               )
               process.exit(1)
             } else {
-              const json = JSON.parse(body)
-              hk.styledHeader(
-                `Domain ${
-                  context.args.domain
-                } has been queued for TLS certificate addition. This may take a few minutes.`
-              )
-              hk.warn(
-                'In the mean time, start the domain verification process by creating a DNS TXT record containing the following content: \n'
-              )
-              hk.warn(json.metatag)
-              hk.warn(
-                'Once you have added this TXT record you can start the verification process by running:\n'
-              )
-              hk.warn('$ heroku fastly:verify start DOMAIN —app APP')
+              const output = JSON.parse(body)
+              if (Array.isArray(output.msg)) {
+                output.msg.forEach(message => {
+                  if (!message.success) {
+                    if (Array.isArray(message.errors)) {
+                      message.errors.forEach(error => hk.error(error))
+                    }
+                  }
+                })
+              }
+              if (output.metatag) {
+                hk.styledHeader(
+                  `Domain ${
+                    context.args.domain
+                  } has been queued for TLS certificate addition. This may take a few minutes.`
+                )
+                hk.warn(
+                  'In the mean time, start the domain verification process by creating a DNS TXT record containing the following content: \n'
+                )
+                hk.warn(output.metatag)
+                hk.warn(
+                  'Once you have added this TXT record you can start the verification process by running:\n'
+                )
+                hk.warn('$ heroku fastly:verify start DOMAIN —app APP')
+              } else {
+                hk.warn('Unable to process this request.')
+              }
             }
           }
         )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastly/heroku-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Heroku CLI Plugin for interacting with Fastly CDN",
   "homepage": "https://www.fastly.com",
   "main": "index.js",


### PR DESCRIPTION
Currenty if there's an error with the backend and a user tries to create a TLS certificate, the system used to gaslight the user and tell them everything was fine and please use a nonexistant CNAME. Now it gives an error message with something that customer-support can use instead of getting engineering involved to dismantle the entire application first.

Old Error:
![old-error](https://cl.ly/e604aec5c0fb/Image%2525202019-02-21%252520at%25252016.17.10.png)


New Error:
![new-error](https://cl.ly/bea5c32eaeea/Image%2525202019-02-21%252520at%25252016.10.28.png)
